### PR TITLE
Ensure gecos string has at least two fields

### DIFF
--- a/src/cc/journeyman/real_name/core.clj
+++ b/src/cc/journeyman/real_name/core.clj
@@ -33,7 +33,7 @@
   "Process this `gecos` field into a map of its sub-fields. See
    https://en.wikipedia.org/wiki/Gecos_field"
   [gecos]
-  (delimited-record->map gecos #"," [:real-name :address :work-phone :home-phone :other]))
+  (delimited-record->map (str gecos ",?") #"," [:real-name :address :work-phone :home-phone :other]))
 
 (defn process-passwd-line
   "Process this `line` from a passwd file"


### PR DESCRIPTION
For a `gecos` string like `,,,`, `clojure.string/split` produces `[]` so `interleave` produces an empty result (it stops on the shortest sequence) and so the `apply assoc` fails with two few arguments.

This ensures that the `gecos` string will always produce a non-empty result from the `split` so the rest works.

Note that `(split "a,,," #",")` produces `["a"]` -- the empty trailing elements are ignored/dropped.